### PR TITLE
Add new configuration variable tail_comma_braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
 
 *   **argwrap_tail_comma**
 
-    Specifies if the closing brace should be preceded with a comma when wrapping lines.
+    Specifies if any closing brace should be preceded with a comma when wrapping lines.
 
     *Tail comma disabled (default)*
 
@@ -97,6 +97,30 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
         wobble,
         wubble,
     )
+    ```
+
+*   **argwrap_tail_comma_braces**
+
+    Specifies which closing brace should be preceded with a comma when wrapping lines.
+
+    *Tail comma disabled (default)*
+
+    ```
+    Foo(
+        wibble,
+        wobble,
+        wubble
+    )
+    ```
+
+    *Tail comma enabled for square brackets only (`let g:argwrap_tail_comma_braces = '['`)*
+
+    ```
+    r = [
+        2,
+        3,
+        5,
+    ]
     ```
 
 *   **argwrap_wrap_closing_brace**

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -159,6 +159,7 @@ endfunction
 function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComma, tailCommaBraces, linePrefix, commaFirst)
     let l:argCount = len(a:arguments)
     let l:line = a:range.lineStart
+    let l:prefix = a:container.prefix[len(a:container.prefix) - 1]
 
     call setline(l:line, a:container.indent . a:container.prefix)
 
@@ -175,7 +176,7 @@ function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComm
             let l:text .= a:arguments[l:index]
         else
             let l:text .= a:container.indent . a:linePrefix . a:arguments[l:index]
-            if  !l:last || a:tailComma || a:tailCommaBraces =~ a:container.prefix
+            if  !l:last || a:tailComma || a:tailCommaBraces =~ l:prefix
                 let l:text .= ','
             end
         end

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -156,7 +156,7 @@ function! argwrap#extractContainer(range)
     return {'indent': l:indent, 'prefix': l:prefix, 'suffix': l:suffix}
 endfunction
 
-function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComma, linePrefix, commaFirst)
+function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComma, tailCommaBraces, linePrefix, commaFirst)
     let l:argCount = len(a:arguments)
     let l:line = a:range.lineStart
 
@@ -175,7 +175,7 @@ function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComm
             let l:text .= a:arguments[l:index]
         else
             let l:text .= a:container.indent . a:linePrefix . a:arguments[l:index]
-            if  !l:last || a:tailComma
+            if  !l:last || a:tailComma || a:tailCommaBraces =~ a:container.prefix
                 let l:text .= ','
             end
         end
@@ -226,6 +226,7 @@ function! argwrap#toggle()
     let l:linePrefix = argwrap#getSetting('line_prefix', '')
     let l:padded = argwrap#getSetting('padded_braces', '')
     let l:tailComma = argwrap#getSetting('tail_comma', 0)
+    let l:tailCommaBraces = argwrap#getSetting('tail_comma_braces', '')
     let l:wrapBrace = argwrap#getSetting('wrap_closing_brace', 1)
     let l:commaFirst = argwrap#getSetting('comma_first', 0)
 
@@ -242,7 +243,7 @@ function! argwrap#toggle()
 
     let l:container = argwrap#extractContainer(l:range)
     if l:range.lineStart == l:range.lineEnd
-        call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:linePrefix, l:commaFirst)
+        call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:linePrefix, l:commaFirst)
     else
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
     endif

--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -73,7 +73,7 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
 <
     Padding can be specified for multiple brace types ()
 *   argwrap_tail_comma
-    Specifies if the closing brace should be preceded with a comma when wrapping lines.
+    Specifies if any closing brace should be preceded with a comma when wrapping lines.
     Tail comma disabled (default)
 >
         Foo(
@@ -89,6 +89,24 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
             wobble,
             wubble,
         )
+<
+*   argwrap_tail_comma_braces
+    Specifies which closing brace should be preceded with a comma when wrapping lines.
+    Tail comma disabled (default)
+>
+        Foo(
+            wibble,
+            wobble,
+            wubble
+        )
+<
+    Tail comma enabled for square brackets ()
+>
+        r = [
+            3,
+            5,
+            8,
+        ]
 <
 *   argwrap_wrap_closing_brace
     Specifies if the closing brace should be wrapped to a new line.


### PR DESCRIPTION
The following patch adds a new configuration variable that lets user select which closing brace should be preceded with a comma.

This should also fix this: https://github.com/FooSoft/vim-argwrap/issues/6
