### PR TITLE
readme: fix tail comma disabled example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
     *Tail comma disabled (default)*
 
     ```
-    Foo(
-        wibble,
-        wobble,
-        wubble
-    )
+    r = [
+        2,
+        3,
+        5
+    ]
     ```
 
     *Tail comma enabled for square brackets only (`let g:argwrap_tail_comma_braces = '['`)*


### PR DESCRIPTION
The section on `argwrap_tail_comma_braces` gives an example using a function. This change fixes that example.