### PR TITLE
Seamless Toggling of Wrapped/Unwrapped States

### DIFF
--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -259,6 +259,7 @@ function! argwrap#toggle()
         call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:tailIndentBraces, l:linePrefix, l:commaFirst, l:commaFirstIndent)
     else
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
+        let l:cursor[1] = l:range.lineStart
     endif
 
     call setpos('.', l:cursor)

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -257,6 +257,7 @@ function! argwrap#toggle()
     let l:container = argwrap#extractContainer(l:range)
     if l:range.lineStart == l:range.lineEnd
         call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:tailIndentBraces, l:linePrefix, l:commaFirst, l:commaFirstIndent)
+        let l:cursor[1] = l:range.lineStart + 1
     else
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
         let l:cursor[1] = l:range.lineStart


### PR DESCRIPTION
The position changes (or non-changes) when wrapping/unwrapping can be jarring. This PR maintains flow and "spatial idempotency", allowing you to toggle back and forth between wrapped and unwrapped states without moving. Addresses https://github.com/FooSoft/vim-argwrap/issues/7 .

Here is a GIF of it in action:

https://imgur.com/a/PaDZtzA

I am only hitting the "wrap" command key binding repeatedly to cycle back and forth between the wrapped/unwrapped states, with no need for any movements on my part. 