### PR TITLE
fix: prefix ending with spaces

### DIFF
--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -68,6 +68,7 @@ endfunction
 
 function! argwrap#extractContainerArgText(range, linePrefix)
     let l:text = ''
+    let l:trimPattern = printf('\m^\s*\(.\{-}\%%(%s\)\?\)\s*$', escape(a:linePrefix, '\$.*^['))
 
     for l:lineIndex in range(a:range.lineStart, a:range.lineEnd)
         let l:lineText = getline(l:lineIndex)
@@ -84,7 +85,7 @@ function! argwrap#extractContainerArgText(range, linePrefix)
 
         if l:extractStart < l:extractEnd
             let l:extract = l:lineText[l:extractStart : l:extractEnd - 1]
-            let l:extract = substitute(l:extract, '^\s*\(.\{-}\)\s*$', '\1', '')
+            let l:extract = substitute(l:extract, l:trimPattern, '\1', '')
             if stridx(l:extract, a:linePrefix) == 0
                 let l:extract = l:extract[len(a:linePrefix):]
             endif


### PR DESCRIPTION
Hi, first of all thanks for the plugin: I'm loving it!

Then the issue is that using a line prefix that end with a space does not work properly.
For example in VimL with the following declaration:
```vim
autocmd FileType vim let b:argwrap_line_prefix = '\ '
```

The following line will be properly wrapped:
```vim
let t = {'one': 'whatever', 'two': 'whatever'}
```

Into:
```vim
let t = {
  \ 'one': 'whatever',
  \ 'two': 'whatever',
\ }
```

But when trying to unwrap it will do:
```vim
let t = {'one': 'whatever', 'two': 'whatever', \}
```

This is caused by the "trim" done for each "extracted" piece of text,
which result in having `"\"` instead of `"\ "` for the last line.