### PR TITLE
improvement: allow to repeat with .

### DIFF
--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -29,7 +29,7 @@ INSTALLATION                                                                    
 2.  Create a keyboard binding for the `ArgWrap` command inside your `~/.vimrc` file.
     For example, to declare a normal mode mapping, add the following command:
 >
-        nnoremap <silent> <leader>a :ArgWrap<CR>
+        nmap <silent> <leader>a <Plug>(ArgWrapToggle)
 <
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/plugin/argwrap.vim
+++ b/plugin/argwrap.vim
@@ -19,3 +19,6 @@
 
 
 command! ArgWrap call argwrap#toggle()
+
+nnoremap <silent> <Plug>(ArgWrapToggle) :call argwrap#toggle() <BAR>
+  \ silent! call repeat#set("\<Plug>(ArgWrapToggle)")<CR>


### PR DESCRIPTION
Hi,

This will fix the issue #20 
It's now possible to use the `.` key to repeat the wrap/unwrap action.