### PR TITLE
improvement: hooks & PHP open brace handling for methods

### DIFF
--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -219,30 +219,32 @@ function! argwrap#unwrapContainer(range, container, arguments, padded)
     exec printf('silent %d,%dd_', a:range.lineStart + 1, a:range.lineEnd)
 endfunction
 
-function! argwrap#getSetting(name, default)
+function! argwrap#getSetting(name)
     let l:bName = 'b:argwrap_' . a:name
     let l:gName = 'g:argwrap_' . a:name
 
-    if exists(l:bName)
-        return {l:bName}
-    elseif exists(l:gName)
-        return {l:gName}
-    else
-        return a:default
+    return exists(l:bName) ? {l:bName} : {l:gName}
+endfunction
+
+function! argwrap#initSetting(name, value) abort
+    let l:setting = 'g:argwrap_'.a:name
+
+    if !exists(l:setting)
+        let {l:setting} = a:value
     endif
 endfunction
 
 function! argwrap#toggle()
     let l:cursor = getpos('.')
 
-    let l:linePrefix = argwrap#getSetting('line_prefix', '')
-    let l:padded = argwrap#getSetting('padded_braces', '')
-    let l:tailComma = argwrap#getSetting('tail_comma', 0)
-    let l:tailCommaBraces = argwrap#getSetting('tail_comma_braces', '')
-    let l:tailIndentBraces = argwrap#getSetting('tail_indent_braces', '')
-    let l:wrapBrace = argwrap#getSetting('wrap_closing_brace', 1)
-    let l:commaFirst = argwrap#getSetting('comma_first', 0)
-    let l:commaFirstIndent = argwrap#getSetting('comma_first_indent', 0)
+    let l:linePrefix = argwrap#getSetting('line_prefix')
+    let l:padded = argwrap#getSetting('padded_braces')
+    let l:tailComma = argwrap#getSetting('tail_comma')
+    let l:tailCommaBraces = argwrap#getSetting('tail_comma_braces')
+    let l:tailIndentBraces = argwrap#getSetting('tail_indent_braces')
+    let l:wrapBrace = argwrap#getSetting('wrap_closing_brace')
+    let l:commaFirst = argwrap#getSetting('comma_first')
+    let l:commaFirstIndent = argwrap#getSetting('comma_first_indent')
 
     let l:range = argwrap#findClosestRange()
     if !argwrap#validateRange(l:range)

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -260,18 +260,12 @@ function! argwrap#toggle()
         call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:tailIndentBraces, l:linePrefix, l:commaFirst, l:commaFirstIndent)
         let l:cursor[1] = l:range.lineStart + 1
 
-        let l:filetypeHook = printf('argwrap#hooks#%s#post_wrap', &filetype)
-        if exists('*'.l:filetypeHook)
-            call call(l:filetypeHook, [l:range, l:container, l:arguments])
-        endif
+        silent! call argwrap#hooks#{&filetype}#post_wrap(l:range, l:container, l:arguments)
     else
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
         let l:cursor[1] = l:range.lineStart
 
-        let l:filetypeHook = printf('argwrap#hooks#%s#post_unwrap', &filetype)
-        if exists('*'.l:filetypeHook)
-            call call(l:filetypeHook, [l:range, l:container, l:arguments])
-        endif
+        silent! call argwrap#hooks#{&filetype}#post_unwrap(l:range, l:container, l:arguments)
     endif
 
     call setpos('.', l:cursor)

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -257,15 +257,19 @@ function! argwrap#toggle()
 
     let l:container = argwrap#extractContainer(l:range)
     if l:range.lineStart == l:range.lineEnd
+        call argwrap#hooks#execute('pre_wrap', l:range, l:container, l:arguments)
+
         call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:tailIndentBraces, l:linePrefix, l:commaFirst, l:commaFirstIndent)
         let l:cursor[1] = l:range.lineStart + 1
 
-        silent! call argwrap#hooks#{&filetype}#post_wrap(l:range, l:container, l:arguments)
+        call argwrap#hooks#execute('post_wrap', l:range, l:container, l:arguments)
     else
+        call argwrap#hooks#execute('pre_unwrap', l:range, l:container, l:arguments)
+
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
         let l:cursor[1] = l:range.lineStart
 
-        silent! call argwrap#hooks#{&filetype}#post_unwrap(l:range, l:container, l:arguments)
+        call argwrap#hooks#execute('post_unwrap', l:range, l:container, l:arguments)
     endif
 
     call setpos('.', l:cursor)

--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -259,9 +259,19 @@ function! argwrap#toggle()
     if l:range.lineStart == l:range.lineEnd
         call argwrap#wrapContainer(l:range, l:container, l:arguments, l:wrapBrace, l:tailComma, l:tailCommaBraces, l:tailIndentBraces, l:linePrefix, l:commaFirst, l:commaFirstIndent)
         let l:cursor[1] = l:range.lineStart + 1
+
+        let l:filetypeHook = printf('argwrap#hooks#%s#post_wrap', &filetype)
+        if exists('*'.l:filetypeHook)
+            call call(l:filetypeHook, [l:range, l:container, l:arguments])
+        endif
     else
         call argwrap#unwrapContainer(l:range, l:container, l:arguments, l:padded)
         let l:cursor[1] = l:range.lineStart
+
+        let l:filetypeHook = printf('argwrap#hooks#%s#post_unwrap', &filetype)
+        if exists('*'.l:filetypeHook)
+            call call(l:filetypeHook, [l:range, l:container, l:arguments])
+        endif
     endif
 
     call setpos('.', l:cursor)

--- a/autoload/argwrap/hooks.vim
+++ b/autoload/argwrap/hooks.vim
@@ -1,0 +1,45 @@
+function! s:loadGlobalHooks() abort " {{{
+  if !exists('g:argwrap_global_hooks')
+    let g:argwrap_global_hooks = []
+
+    for hook in globpath(&runtimepath, 'autoload/argwrap/hooks/*.vim', 0, 1)
+      let l:filename = matchstr(hook, '\vhooks/\zs.+\ze\.vim$')
+
+      call add(g:argwrap_global_hooks, printf('argwrap#hooks#%s', l:filename))
+    endfor
+  endif
+
+  return g:argwrap_global_hooks
+endfunction " }}}
+
+function! s:loadFiletypeHooks(filetype) abort " {{{
+  if !exists('g:argwrap_filetype_hooks.'.a:filetype)
+    let g:argwrap_filetype_hooks[a:filetype] = []
+    let l:hooks = g:argwrap_filetype_hooks[a:filetype]
+
+    for filetypeHook in globpath(&runtimepath, 'autoload/argwrap/hooks/filetype/*/*.vim', 0, 1)
+      let l:filetype = matchstr(filetypeHook, '\vhooks/filetype/\zs.+\ze/.+\.vim$')
+      let l:filename = matchstr(filetypeHook, '\vhooks/filetype/.+/\zs.+\ze\.vim$')
+
+      call add(l:hooks, printf('argwrap#hooks#filetype#%s#%s', l:filetype, l:filename))
+    endfor
+  endif
+
+  return g:argwrap_filetype_hooks[a:filetype]
+endfunction " }}}
+
+function! s:load() abort " {{{
+  if !exists('b:argwrap_hooks')
+    let b:argwrap_hooks = s:loadGlobalHooks() + s:loadFiletypeHooks(&filetype)
+  endif
+
+  return b:argwrap_hooks
+endfunction " }}}
+
+function! argwrap#hooks#execute(name, ...) abort " {{{
+  for hook in s:load()
+    silent! call call(printf('%s#%s', hook, a:name), a:000)
+  endfor
+endfunction " }}}
+
+" vim: ts=2 sw=2 et fdm=marker

--- a/autoload/argwrap/hooks.vim
+++ b/autoload/argwrap/hooks.vim
@@ -37,7 +37,15 @@ function! s:load() abort " {{{
 endfunction " }}}
 
 function! argwrap#hooks#execute(name, ...) abort " {{{
-  for hook in s:load()
+  " Reverse the order of the hooks for post hooks so that a pre hook with a
+  " low priority is executed before and a post hook is executed after
+  " For instance for a hook responsible to preserve the cursor position it
+  " must be the first to be executed to save the position of the cursor but
+  " the last to be executed to restore it after all other hooks have been
+  " executed
+  let l:hooks = a:name =~? '\v^post' ? reverse(copy(s:load())) : s:load()
+
+  for hook in l:hooks
     silent! call call(printf('%s#%s', hook, a:name), a:000)
   endfor
 endfunction " }}}

--- a/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
@@ -10,18 +10,6 @@ function! s:dealWithMethodArguments(container) abort " {{{
   return 1
 endfunction " }}}
 
-function! argwrap#hooks#php#post_wrap(range, container, arguments) abort " {{{
-  if argwrap#getSetting('php_smart_brace', 0)
-    call s:fixMethodOpeningBraceAfterWrap(a:range, a:container, a:arguments)
-  endif
-endfunction  " }}}
-
-function! argwrap#hooks#php#post_unwrap(range, container, arguments) abort " {{{
-  if argwrap#getSetting('php_smart_brace', 0)
-    call s:fixMethodOpeningBraceAfterUnwrap(a:range, a:container, a:arguments)
-  endif
-endfunction  " }}}
-
 function! s:fixMethodOpeningBraceAfterWrap(range, container, arguments) abort " {{{
   if !s:dealWithMethodArguments(a:container)
     return
@@ -56,5 +44,29 @@ function! s:fixMethodOpeningBraceAfterUnwrap(range, container, arguments) abort 
 
   execute printf("undojoin | normal! %dG0%dlct{\<CR>", a:range.lineStart, l:col)
 endfunction " }}}
+
+function! argwrap#hooks#filetype#php#200_smart_brace#pre_wrap(range, container, arguments) abort " {{{
+  " Do nothing but prevent the file to be loaded more than once
+  " When calling an autoload function that is not define the script that
+  " should contain it is sourced every time the function is called
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_smart_brace#pre_unwrap(range, container, arguments) abort " {{{
+  " Do nothing but prevent the file to be loaded more than once
+  " When calling an autoload function that is not define the script that
+  " should contain it is sourced every time the function is called
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_smart_brace#post_wrap(range, container, arguments) abort " {{{
+  if argwrap#getSetting('php_smart_brace', 0)
+    call s:fixMethodOpeningBraceAfterWrap(a:range, a:container, a:arguments)
+  endif
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_smart_brace#post_unwrap(range, container, arguments) abort " {{{
+  if argwrap#getSetting('php_smart_brace', 0)
+    call s:fixMethodOpeningBraceAfterUnwrap(a:range, a:container, a:arguments)
+  endif
+endfunction  " }}}
 
 " vim: ts=2 sw=2 et fdm=marker

--- a/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
@@ -18,10 +18,7 @@ function! s:fixMethodOpeningBraceAfterWrap(range, container, arguments) abort " 
   let l:lineEnd = a:range.lineEnd + len(a:arguments)
 
   " Add 1 more line if the brace is also wrapped
-  " TODO define default values on the plugin level so that extension can
-  " request an option value without having to pass them all as argument or
-  " having to duplicate the default value
-  if 0 != argwrap#getSetting('wrap_closing_brace', 1)
+  if 0 != argwrap#getSetting('wrap_closing_brace')
     let l:lineEnd += 1
   endif
 
@@ -55,13 +52,13 @@ function! argwrap#hooks#filetype#php#200_smart_brace#pre_unwrap(range, container
 endfunction  " }}}
 
 function! argwrap#hooks#filetype#php#200_smart_brace#post_wrap(range, container, arguments) abort " {{{
-  if argwrap#getSetting('php_smart_brace', 0)
+  if argwrap#getSetting('php_smart_brace')
     call s:fixMethodOpeningBraceAfterWrap(a:range, a:container, a:arguments)
   endif
 endfunction  " }}}
 
 function! argwrap#hooks#filetype#php#200_smart_brace#post_unwrap(range, container, arguments) abort " {{{
-  if argwrap#getSetting('php_smart_brace', 0)
+  if argwrap#getSetting('php_smart_brace')
     call s:fixMethodOpeningBraceAfterUnwrap(a:range, a:container, a:arguments)
   endif
 endfunction  " }}}

--- a/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
@@ -35,14 +35,11 @@ function! s:fixMethodOpeningBraceAfterUnwrap(range, container, arguments) abort 
     return
   endif
 
-  if a:container.suffix !~ '\v^\)\s*\{'
+  if a:container.suffix !~ '\v^\).*\{\s*$'
     return
   endif
 
-  " +1 to get the position after the closing parenthesis
-  let l:col = stridx(getline(a:range.lineStart), a:container.suffix) + 1
-
-  execute printf("undojoin | normal! %dG0%dlct{\<CR>", a:range.lineStart, l:col)
+  execute printf("undojoin | normal! %dG$F{i\<CR>", a:range.lineStart)
 endfunction " }}}
 
 function! argwrap#hooks#filetype#php#200_smart_brace#pre_wrap(range, container, arguments) abort " {{{

--- a/autoload/argwrap/hooks/php.vim
+++ b/autoload/argwrap/hooks/php.vim
@@ -1,0 +1,60 @@
+function! s:dealWithMethodArguments(container) abort " {{{
+  if a:container.suffix !~ '\v^\)'
+    return 0
+  endif
+
+  if a:container.prefix !~? '\v^%(public|protected|private)\s+function\s+\S+\s*\($'
+    return 0
+  endif
+
+  return 1
+endfunction " }}}
+
+function! argwrap#hooks#php#post_wrap(range, container, arguments) abort " {{{
+  if argwrap#getSetting('php_smart_brace', 0)
+    call s:fixMethodOpeningBraceAfterWrap(a:range, a:container, a:arguments)
+  endif
+endfunction  " }}}
+
+function! argwrap#hooks#php#post_unwrap(range, container, arguments) abort " {{{
+  if argwrap#getSetting('php_smart_brace', 0)
+    call s:fixMethodOpeningBraceAfterUnwrap(a:range, a:container, a:arguments)
+  endif
+endfunction  " }}}
+
+function! s:fixMethodOpeningBraceAfterWrap(range, container, arguments) abort " {{{
+  if !s:dealWithMethodArguments(a:container)
+    return
+  endif
+
+  let l:lineEnd = a:range.lineEnd + len(a:arguments)
+
+  " Add 1 more line if the brace is also wrapped
+  " TODO define default values on the plugin level so that extension can
+  " request an option value without having to pass them all as argument or
+  " having to duplicate the default value
+  if 0 != argwrap#getSetting('wrap_closing_brace', 1)
+    let l:lineEnd += 1
+  endif
+
+  if getline(l:lineEnd + 1) =~ '\v^\s*\{'
+    execute printf('undojoin | normal! %dGJ', l:lineEnd)
+  endif
+endfunction " }}}
+
+function! s:fixMethodOpeningBraceAfterUnwrap(range, container, arguments) abort " {{{
+  if !s:dealWithMethodArguments(a:container)
+    return
+  endif
+
+  if a:container.suffix !~ '\v^\)\s*\{'
+    return
+  endif
+
+  " +1 to get the position after the closing parenthesis
+  let l:col = stridx(getline(a:range.lineStart), a:container.suffix) + 1
+
+  execute printf("undojoin | normal! %dG0%dlct{\<CR>", a:range.lineStart, l:col)
+endfunction " }}}
+
+" vim: ts=2 sw=2 et fdm=marker

--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -179,6 +179,23 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
             , wubble
         )
 <
+*   argwrap_php_smart_brace
+    Specifies if the opening brace of PHP methods should be wrap/unwrap as well.
+    PHP smart brace disabled (default)
+>
+        public function foo(
+            int $x,
+            int $y
+        )
+        {
+<
+    PHP smart brace enabled ()
+>
+        public function foo(
+            int $x,
+            int $y
+        ) {
+<
 
 ------------------------------------------------------------------------------------------------------------------------
 USAGE                                                                                                      *argwrap-usage*

--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -227,6 +227,18 @@ Global hooks will be executed before filetype ones.
 Global and filetype hooks are sorted by the |globpath()| function. Meaning you
 can control the execution order of the hooks by prefixing them with a
 priority.
+Post hooks order is reversed in order to keep the execution order logical.
+
+For example if there two hooks named `000_cursor` and `200_anything` , the
+cursor hook being responsible to preserve the cursor position it must be
+executed first to ensure no modification of the cursor position has been done
+yet so it receive the lowest priority.
+The execution stack for a wrap operation would then be:
+    - `000_cursor#pre_wrap`
+    - `000_anything#pre_wrap`
+    - `wrap operation`
+    - `000_anything#post_wrap`
+    - `000_cursor#post_wrap`
 
 
 An important things to know when writing a new hook is that calling an

--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -6,8 +6,9 @@ CONTENTS                                                                        
 1. ArgWrap...............................................................................................|argwrap-argwrap|
     1.1. Installation...............................................................................|argwrap-installation|
     1.2. Configuration.............................................................................|argwrap-configuration|
-    1.3. Usage.............................................................................................|argwrap-usage|
-    1.4. License.........................................................................................|argwrap-license|
+    1.3. Hooks.............................................................................................|argwrap-hooks|
+    1.4. Usage.............................................................................................|argwrap-usage|
+    1.5. License.........................................................................................|argwrap-license|
 
 ========================================================================================================================
 ARGWRAP                                                                                                  *argwrap-argwrap*
@@ -198,6 +199,66 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
 <
 
 ------------------------------------------------------------------------------------------------------------------------
+HOOKS                                                                                                      *argwrap-hooks*
+
+It is possible to hook before or after a  wrap/unwrap operation using
+autoloaded functions, the hooks are named:
+    - `pre_wrap`
+    - `pre_unwrap`
+    - `post_wrap`
+    - `post_unwrap`
+
+For example to do something after any wrap create a function: >
+    argwrap#hooks#my_hook#post_wrap(range, container, arguments)
+<
+It is also possible to create a hook for a specific filetype: >
+    argwrap#hooks#filetype#vim#my_hook#post_wrap(range, container, arguments)
+<
+
+Global hooks are loaded on the first time a wrap/unwrap operation is done.
+Filetype hooks however are only loaded for the current filetype.
+You can see the list of loaded hooks with: >
+    echo g:argwrap_global_hooks
+    echo g:argwrap_filetype_hooks
+    echo b:argwrap_hooks
+<
+The hooks are loaded from any directory specified in the |runtimepath|.
+Global hooks will be executed before filetype ones.
+Global and filetype hooks are sorted by the |globpath()| function. Meaning you
+can control the execution order of the hooks by prefixing them with a
+priority.
+
+
+An important things to know when writing a new hook is that calling an
+|autoload| function which does not exist will source the file that should
+contain the function every time.
+So even if you do not need one of the hook, always define them all. This is a
+template you can use to get started: >
+    function! argwrap#hooks#my_hook#pre_wrap(range, container, arguments) abort " {{{
+      " Do nothing but prevent the file to be loaded more than once
+      " When calling an autoload function that is not define the script that
+      " should contain it is sourced every time the function is called
+    endfunction  " }}}
+
+    function! argwrap#hooks#my_hook#pre_unwrap(range, container, arguments) abort " {{{
+      " Do nothing but prevent the file to be loaded more than once
+      " When calling an autoload function that is not define the script that
+      " should contain it is sourced every time the function is called
+    endfunction  " }}}
+
+    function! argwrap#hooks#my_hook#post_wrap(range, container, arguments) abort " {{{
+      " Do nothing but prevent the file to be loaded more than once
+      " When calling an autoload function that is not define the script that
+      " should contain it is sourced every time the function is called
+    endfunction  " }}}
+
+    function! argwrap#hooks#my_hook#post_unwrap(range, container, arguments) abort " {{{
+      " Do nothing but prevent the file to be loaded more than once
+      " When calling an autoload function that is not define the script that
+      " should contain it is sourced every time the function is called
+    endfunction  " }}}
+<
+------------------------------------------------------------------------------------------------------------------------
 USAGE                                                                                                      *argwrap-usage*
 
 1.  Position the cursor inside of the scope of the parenthesis, brackets or curly braces you wish to wrap/unwrap (not
@@ -224,3 +285,4 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+ vim:tw=78:sw=4:ft=help:norl:

--- a/plugin/argwrap.vim
+++ b/plugin/argwrap.vim
@@ -17,6 +17,7 @@
 " IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 " CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+let g:argwrap_filetype_hooks = {}
 
 command! ArgWrap call argwrap#toggle()
 

--- a/plugin/argwrap.vim
+++ b/plugin/argwrap.vim
@@ -17,7 +17,16 @@
 " IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 " CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-let g:argwrap_filetype_hooks = {}
+call argwrap#initSetting('line_prefix', '')
+call argwrap#initSetting('padded_braces', '')
+call argwrap#initSetting('tail_comma', 0)
+call argwrap#initSetting('tail_comma_braces', '')
+call argwrap#initSetting('tail_indent_braces', '')
+call argwrap#initSetting('wrap_closing_brace', 1)
+call argwrap#initSetting('comma_first', 0)
+call argwrap#initSetting('comma_first_indent', 0)
+call argwrap#initSetting('filetype_hooks', {})
+call argwrap#initSetting('php_smart_brace', 0)
 
 command! ArgWrap call argwrap#toggle()
 


### PR DESCRIPTION
Hi,

This one started to resolve the #19 
It's a work in progress, as I explain in the commits I want to use this PR to also provide a way to easly hook into the plugin.
Currently a user can only add a hook for a filetype and not a global one, also if a hook is already define for the filetype by a plugin it can't be overridden by the user.

The hooks are now more generic and should allow anyone to be able to add new functionalities.
I tried to do it in a way that reduce the performances impact as mutch as possible.
Let me know if you want things done differently.

At the end I'm not sure about this solution, I start wondering if implementing a chain of middleware might not be best...
I'm working on another PR to maintain the position of the cursor relative to the argument underneath it.
And it would be great if the pre event could be the first thing done and the post event the last one. This way it's possible to calculate the position of the cursor before anything else happend and to reposition it after every thing else...
So I put this one back in WIP for now and I will do a POC for the middleware implementation.