### PR TITLE
Add option to start list on same line

### DIFF
--- a/autoload/argwrap.vim
+++ b/autoload/argwrap.vim
@@ -187,8 +187,19 @@ function! argwrap#wrapContainer(range, container, arguments, wrapBrace, tailComm
         end
 
         call append(l:line, l:text)
-        let l:line += 1
-        silent! exec printf('%s>', l:line)
+
+        if !a:wrapBrace
+            if l:first
+                norm! Jx
+                let l:indentation = repeat(" ", getcurpos()[2] - 1)
+            else
+                let l:line += 1
+                call setline(l:line, substitute(getline(l:line), "^ *", l:indentation, ""))
+            endif
+        else
+            let l:line += 1
+            silent! exec printf('%s>', l:line)
+        endif
 
         if l:first && a:commaFirstIndent
             let width = &l:shiftwidth


### PR DESCRIPTION
Description:
This commit adds the option to start a list on the same line, as
proposed in issue #8. By this, a wrapped list would become:

    void foo(var1,
             var2,
             var3)

instead of:

    void foo(
        var1,
        var2,
        var3
    )

For now, the option is implemented using

    let g:argwrap_wrap_closing_brace

The configuration can be extended to see this option as separate, for example `let g:argwrap_wrap_braces`

Warning!
It assumes the indentation is done with spaces instead of tabs

Relevant issue: #8 (https://github.com/FooSoft/vim-argwrap/issues/8)