### PR TITLE
Fix PHP smart brace hook for static method

### DIFF
--- a/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
@@ -3,7 +3,7 @@ function! s:dealWithMethodArguments(container) abort " {{{
     return 0
   endif
 
-  if a:container.prefix !~? '\v^%(public|protected|private)\s+function\s+\S+\s*\($'
+  if a:container.prefix !~? '\v^%(public|protected|private)(\s+static)?\s+function\s+\S+\s*\($'
     return 0
   endif
 

--- a/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_smart_brace.vim
@@ -36,18 +36,18 @@ function! s:fixMethodOpeningBraceAfterUnwrap(range, container, arguments) abort 
     return
   endif
 
-  execute printf("undojoin | normal! %dG$F{i\<CR>", a:range.lineStart)
+  execute printf("undojoin | normal! %dG$F{gelct{\<CR>", a:range.lineStart)
 endfunction " }}}
 
 function! argwrap#hooks#filetype#php#200_smart_brace#pre_wrap(range, container, arguments) abort " {{{
   " Do nothing but prevent the file to be loaded more than once
-  " When calling an autoload function that is not define the script that
+  " When calling an autoload function that is not define, the script that
   " should contain it is sourced every time the function is called
 endfunction  " }}}
 
 function! argwrap#hooks#filetype#php#200_smart_brace#pre_unwrap(range, container, arguments) abort " {{{
   " Do nothing but prevent the file to be loaded more than once
-  " When calling an autoload function that is not define the script that
+  " When calling an autoload function that is not define, the script that
   " should contain it is sourced every time the function is called
 endfunction  " }}}
 


### PR DESCRIPTION
Hi,

There is a bug in the hook I added a few months ago, it does not handle static method.

Todo:
- [x] Just find out a little problem of extra space at the end of line when unwrapping