### PR TITLE
[Improvement] Remove tail comma for php function declarations

### DIFF
--- a/autoload/argwrap/hooks/filetype/php/200_remove_tail_comma_function_declaration.vim
+++ b/autoload/argwrap/hooks/filetype/php/200_remove_tail_comma_function_declaration.vim
@@ -1,0 +1,58 @@
+function! s:dealWithFunctionDeclaration(container) abort " {{{
+  if a:container.suffix !~ '\v^\)'
+    return 0
+  endif
+
+  " Take anonymous and arrow functions into account
+  if a:container.prefix !~? '\v(function|fn)\s*\S*\s*\($'
+    return 0
+  endif
+
+  return 1
+endfunction " }}}
+
+function! argwrap#hooks#filetype#php#200_remove_tail_comma_function_declaration#pre_wrap(range, container, arguments) abort " {{{
+  " Do nothing but prevent the file to be loaded more than once
+  " When calling an autoload function that is not define the script that
+  " should contain it is sourced every time the function is called
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_remove_tail_comma_function_declaration#pre_unwrap(range, container, arguments) abort " {{{
+  " Do nothing but prevent the file to be loaded more than once
+  " When calling an autoload function that is not define the script that
+  " should contain it is sourced every time the function is called
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_remove_tail_comma_function_declaration#post_wrap(range, container, arguments) abort " {{{
+  " Don't do anything if the user want a tail comma for function declaration
+  if 0 == argwrap#getSetting('php_remove_tail_comma_function_declaration')
+    return
+  endif
+
+  let l:tailComma = argwrap#getSetting('tail_comma')
+  let l:tailCommaForFunctionDeclaration = argwrap#getSetting('tail_comma_braces') =~ '('
+
+  " Don't do anything if the tail comma feature is disabled
+  if !l:tailComma && !l:tailCommaForFunctionDeclaration
+    return
+  endif
+
+  " Don't do anything if it's not a function declaration
+  if !s:dealWithFunctionDeclaration(a:container)
+    return
+  endif
+
+  let l:lineEnd = a:range.lineEnd + len(a:arguments)
+
+  if getline(l:lineEnd) =~ '\v,\s*$'
+    call setline(l:lineEnd, substitute(getline(l:lineEnd), '\s*,\s*$', '', ''))
+  endif
+endfunction  " }}}
+
+function! argwrap#hooks#filetype#php#200_remove_tail_comma_function_declaration#post_unwrap(range, container, arguments) abort " {{{
+  " Do nothing but prevent the file to be loaded more than once
+  " When calling an autoload function that is not define the script that
+  " should contain it is sourced every time the function is called
+endfunction  " }}}
+
+" vim: ts=2 sw=2 et fdm=marker

--- a/doc/argwrap.txt
+++ b/doc/argwrap.txt
@@ -197,6 +197,23 @@ file basis using `ftplugin` or `autocmd`. For example, the `argwrap_tail_comma` 
             int $y
         ) {
 <
+*   argwrap_php_remove_tail_comma_function_declaration
+    Removes the tailing comma for PHP function declaration (it's invalid until
+    PHP 8).
+    PHP remove tail comma on function declaration disabled (default)
+>
+        public function foo(
+            int $x,
+            int $y,
+        ) {
+<
+    PHP remove tail comma on function declaration enabled
+>
+        public function foo(
+            int $x,
+            int $y
+        ) {
+<
 
 ------------------------------------------------------------------------------------------------------------------------
 HOOKS                                                                                                      *argwrap-hooks*

--- a/plugin/argwrap.vim
+++ b/plugin/argwrap.vim
@@ -27,6 +27,7 @@ call argwrap#initSetting('comma_first', 0)
 call argwrap#initSetting('comma_first_indent', 0)
 call argwrap#initSetting('filetype_hooks', {})
 call argwrap#initSetting('php_smart_brace', 0)
+call argwrap#initSetting('php_remove_tail_comma_function_declaration', 0)
 
 command! ArgWrap call argwrap#toggle()
 


### PR DESCRIPTION
Hi,

This improvement aims to handle trailing comma with functions and methods in PHP.
Since PHP 7.3 trailing comma in function calls is a valid syntax.
But until PHP 8 tailing comma in function declarations will still be invalid.

Argwrap already allows us to add the trailing comma with either `argwrap_trailing_comma = 1` or `argwrap_trailing_comma_braces = '('`options.
This PR adds a new option `argwrap_php_remove_tail_comma_function_declaration`, disabled by default, which activates a new hook that will remove the trailing comma only for function or method declarations.

The hook also handle arrow functions that were introduced in PHP 7.4.